### PR TITLE
fix: correctly build classnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@g123jp/g123-ui",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Reuseable UI based on G123 Design System",
   "author": "hydRAnger <armyiljfe@gmail.com>",
   "license": "MIT",

--- a/src/components/Atoms/Badge.tsx
+++ b/src/components/Atoms/Badge.tsx
@@ -25,7 +25,7 @@ const Badge: React.VFC<Props> = ({
     <div className="flex relative w-fit">
       {children}
       <div
-        className="absolute font-extrabold text-white whitespace-nowrap rounded-lg border-2 border-white text-xxs bg-danger"
+        className="absolute text-xxs font-extrabold text-white whitespace-nowrap bg-danger rounded-lg border-2 border-white"
         style={{
           padding: '1px 3px',
           top: `${offsetTop}px`,
@@ -39,7 +39,7 @@ const Badge: React.VFC<Props> = ({
     <div className="flex relative w-fit">
       {children}
       <div
-        className="absolute w-2 h-2 rounded-full bg-danger"
+        className="absolute w-2 h-2 bg-danger rounded-full"
         style={{ top: `${offsetTop}px`, right: `${offsetRight}px` }}
       />
     </div>

--- a/src/components/Atoms/ChevronButton.stories.tsx
+++ b/src/components/Atoms/ChevronButton.stories.tsx
@@ -20,7 +20,7 @@ export default {
 } as ComponentMeta<typeof ChevronButton>;
 
 const Template: ComponentStory<typeof ChevronButton> = (args) => (
-  <div className="text-default">
+  <div>
     <ChevronButton type={ChevronButtonType.up} />
     <ChevronButton className="text-primary" type={ChevronButtonType.right} />
     <ChevronButton className="text-secondary" type={ChevronButtonType.down} />

--- a/src/components/Organisms/Dialog/Dialog.stories.tsx
+++ b/src/components/Organisms/Dialog/Dialog.stories.tsx
@@ -14,7 +14,7 @@ const Template: ComponentStory<typeof Dialog> = () => (
   <div className="flex flex-col gap-y-8 w-full h-full">
     <DialogContainer />
 
-    <div className="flex gap-2 w-full h-full items-center">
+    <div className="flex gap-2 items-center w-full h-full">
       <h2>Size:</h2>
       <Button
         size={ButtonSize.small}

--- a/src/components/Organisms/Dialog/Dialog.tsx
+++ b/src/components/Organisms/Dialog/Dialog.tsx
@@ -95,7 +95,7 @@ const Dialog: React.VFC<Props> = (props) => {
     >
       <div
         aria-label="Close Dialog"
-        className="fixed top-0 w-full h-full bg-black bg-opacity-30 backdrop-blur transition-opacity"
+        className="fixed top-0 w-full h-full bg-black/30 backdrop-blur transition-opacity"
         role="button"
         tabIndex={0}
         onClick={events.handleBackdropClick}

--- a/src/components/Organisms/Modal/index.tsx
+++ b/src/components/Organisms/Modal/index.tsx
@@ -31,22 +31,7 @@ const Content: React.VFC<{ children: ReactNode }> = ({ children }) => {
   return (
     <div
       aria-hidden="true"
-      className={`
-        animate-slide-in-bottom
-        block
-        box-border
-        bg-white
-        fixed
-        left-0
-        right-0
-        -bottom-3
-        z-50
-        w-full
-        overflow-x-hidden
-        overflow-y-hidden
-        rounded-t-xl
-        rounded-b-none
-      `}
+      className="box-border block overflow-hidden fixed inset-x-0 -bottom-3 z-50 w-full bg-white rounded-t-xl rounded-b-none animate-slide-in-bottom"
       style={{ height: '36rem' }}
       onClick={(e: React.MouseEvent): void => {
         e.preventDefault();

--- a/src/components/Summary.stories.tsx
+++ b/src/components/Summary.stories.tsx
@@ -37,14 +37,14 @@ const Template: ComponentStory<typeof Badge> = () => (
         <Button type={ButtonType.text}>Text</Button>
       </div>
       {/* Button Size */}
-      <div className="flex items-center gap-2">
+      <div className="flex gap-2 items-center">
         <Button size={ButtonSize.small}>Small</Button>
         <Button size={ButtonSize.middle}>Middle</Button>
         <Button size={ButtonSize.large}>Large</Button>
         <Button block>Block</Button>
       </div>
       {/* UX */}
-      <div className="flex items-center gap-2">
+      <div className="flex gap-2 items-center">
         <Button>Normal</Button>
         <Button disabled>Disabled</Button>
       </div>


### PR DESCRIPTION
seems when rollup handle with classnames in template literals with a new line, the output like '-bottom-3\n' will be missed when tailwindcss try to solve it.

<img width="326" alt="image" src="https://user-images.githubusercontent.com/1228449/155697553-730f4cf2-9f89-4b95-96f8-764a47e60cd1.png">

if possible, will make a issue or PR to tailwindcss
