### PR TITLE
fix: animation fade out fill mode

### DIFF
--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -112,7 +112,7 @@ module.exports = {
       },
       animation: {
         'fade-in-bottom': 'fade-in-bottom 0.4s ease-out',
-        'fade-out-bottom': 'fade-out-bottom 0.4s ease-out',
+        'fade-out-bottom': 'fade-out-bottom 0.4s ease-out forwards',
         'slide-in-bottom':
           'slide-in-bottom 0.4s cubic-bezier(0.2, 0.8, 0.2, 1)',
         'slide-in-left': 'slide-in-left 0.4s cubic-bezier(0.2, 0.8, 0.2, 1)',


### PR DESCRIPTION
## Before

The "glitch" can be observed because of the fill-mode, the style returned to its original state after the animation ends.

![Kapture 2023-08-30 at 14 22 36](https://github.com/G123-jp/g123-ui/assets/142764367/0c8f526c-aede-4ffd-a530-650f50d24f51)

## After

It's fixed after changing the fill-mode from default to forwards, which preserve the last state of the animation

![Kapture 2023-08-30 at 14 26 49](https://github.com/G123-jp/g123-ui/assets/142764367/35b1e641-9ec8-4ba7-9fdc-6983c03b05f6)
