### PR TITLE
feat: update carousel props

### DIFF
--- a/src/components/Molecules/Carousel.stories.tsx
+++ b/src/components/Molecules/Carousel.stories.tsx
@@ -9,8 +9,10 @@ export default {
   component: Carousel,
 } as Meta<typeof Carousel>;
 
+type Story = StoryFn<typeof Carousel>;
+
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: StoryFn<typeof Carousel> = () => (
+const Template: Story = () => (
   <div className="h-full w-full">
     <Carousel className="w-72 gap-x-4 py-4">
       <Carousel.Item className="rounded bg-primary">
@@ -35,3 +37,71 @@ const Template: StoryFn<typeof Carousel> = () => (
 export const Default = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Default.args = {};
+
+const CarouselWithScrollbar: Story = () => {
+  return (
+    <div className="h-full w-full">
+      <Carousel
+        className="w-72 gap-x-4 py-4"
+        scrollbarClassName="max-[1024px]:scrollbar-none"
+      >
+        <Carousel.Item className="rounded bg-primary">
+          <h1 className="flex h-20 w-60 items-center justify-center gap-x-2">
+            <Logo /> 1
+          </h1>
+        </Carousel.Item>
+        <Carousel.Item className="rounded bg-secondary">
+          <h1 className="flex h-20 w-60 items-center justify-center gap-x-2">
+            <Logo /> 2
+          </h1>
+        </Carousel.Item>
+        <Carousel.Item className="rounded bg-highlight">
+          <h1 className="flex h-20 w-60 items-center justify-center gap-x-2">
+            <Logo /> 3
+          </h1>
+        </Carousel.Item>
+      </Carousel>
+    </div>
+  );
+};
+
+export const WithScrollbar = CarouselWithScrollbar.bind({});
+
+const CarouselWithNavigation: Story = () => {
+  const ID = 'test-carousel';
+  function navigate(num: number): void {
+    const element = document.getElementById(ID);
+    const width = element?.querySelector('div')?.clientWidth || 0;
+    element?.scrollBy(width * num, 0);
+  }
+  return (
+    <div className="h-full w-full">
+      <Carousel className="w-72 gap-x-4 py-4" id={ID}>
+        <Carousel.Item className="rounded bg-primary">
+          <h1 className="flex h-20 w-60 items-center justify-center gap-x-2">
+            <Logo /> 1
+          </h1>
+        </Carousel.Item>
+        <Carousel.Item className="rounded bg-secondary">
+          <h1 className="flex h-20 w-60 items-center justify-center gap-x-2">
+            <Logo /> 2
+          </h1>
+        </Carousel.Item>
+        <Carousel.Item className="rounded bg-highlight">
+          <h1 className="flex h-20 w-60 items-center justify-center gap-x-2">
+            <Logo /> 3
+          </h1>
+        </Carousel.Item>
+      </Carousel>
+      <button type="button" onClick={(): void => navigate(-1)}>
+        left
+      </button>
+      &nbsp;
+      <button type="button" onClick={(): void => navigate(1)}>
+        right
+      </button>
+    </div>
+  );
+};
+
+export const WithNavigation = CarouselWithNavigation.bind({});

--- a/src/components/Molecules/Carousel.tsx
+++ b/src/components/Molecules/Carousel.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import React from 'react';
 import { twMerge } from 'tailwind-merge';
 
@@ -26,19 +27,25 @@ type Props = {
   className?: string;
   style?: React.CSSProperties;
   children: React.ReactNode;
+  id?: string;
+  scrollbarClassName?: string;
 };
 
 const InternalCarousel: React.VFC<Props> = ({
   style,
   className = '',
+  id,
+  scrollbarClassName = 'scrollbar-none',
   children,
 }) => {
   return (
     <div
       className={twMerge(
-        'flex snap-x snap-mandatory overflow-x-auto scroll-smooth scrollbar-none',
+        'flex snap-x snap-mandatory overflow-x-auto scroll-smooth',
+        scrollbarClassName,
         className,
       )}
+      id={id}
       {...(style && { style })}
     >
       {children}


### PR DESCRIPTION
1. Support `id`
2. Support `scrollbarClassName ` to customized scrollbar, we need this instead of `className` because scrollbar classname can not be overridden according to here: https://github.com/adoxography/tailwind-scrollbar#width-utilities