### PR TITLE
refactor: remove default props

### DIFF
--- a/src/components/Atoms/Badge.tsx
+++ b/src/components/Atoms/Badge.tsx
@@ -67,11 +67,4 @@ const Badge: React.VFC<Props> = ({
   );
 };
 
-Badge.defaultProps = {
-  show: true,
-  content: null,
-  offsetRight: 0,
-  offsetTop: 0,
-};
-
 export default Badge;

--- a/src/components/Atoms/Button.tsx
+++ b/src/components/Atoms/Button.tsx
@@ -201,16 +201,5 @@ const Button: React.VFC<Props> = ({
   );
 };
 
-Button.defaultProps = {
-  type: Type.default,
-  style: undefined,
-  className: '',
-  size: Size.middle,
-  disabled: false,
-  block: false,
-  htmlType: HtmlType.button,
-  onClick: undefined,
-};
-
 export { Type as ButtonType, Size as ButtonSize, HtmlType as ButtonHtmlType };
 export default Button;

--- a/src/components/Organisms/Dialog/Dialog.tsx
+++ b/src/components/Organisms/Dialog/Dialog.tsx
@@ -230,8 +230,4 @@ const Dialog = ({
   );
 };
 
-Dialog.defaultProps = {
-  buttons: undefined,
-};
-
 export default Dialog;

--- a/src/components/Organisms/Drawer/index.tsx
+++ b/src/components/Organisms/Drawer/index.tsx
@@ -48,7 +48,7 @@ type ContentProps = {
 };
 
 const Content: React.VFC<ContentProps> = ({
-  open,
+  open = false,
   isMobile = true,
   title,
   onGoBack,
@@ -178,10 +178,6 @@ const Drawer: React.VFC<Props> = ({
       </Content>
     </Mask>
   );
-};
-
-Drawer.defaultProps = {
-  open: false,
 };
 
 export default Drawer;

--- a/src/components/Organisms/Modal/index.tsx
+++ b/src/components/Organisms/Modal/index.tsx
@@ -92,8 +92,4 @@ const Modal: React.VFC<Props> = ({
   );
 };
 
-Modal.defaultProps = {
-  isOpen: false,
-};
-
 export default Modal;


### PR DESCRIPTION
There is a warning message when using g123-ui, saying that default props should be avoided:

![截圖 2023-09-06 上午9 19 08](https://github.com/G123-jp/g123-ui/assets/142764367/8776ca5a-876d-479f-a0f8-7136e9a26e1c)

I checked the components and found that we already used default parameters in most cases, so default props can be removed safely.