### PR TITLE
Feature: module exports without sideEffects(for tree shaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ yarn add @g123jp/g123-ui
   ```typescript
   import { g123TailwindPresets } from '@g123jp/g123-ui';
 
-  const TailindConfig = {
+  const TailwindConfig = {
     // use g123-ui's presets as default
     presets: [g123TailwindPresets],
     content: [
       // ... put your content here
-      './node_modules/@g123jp/g123-ui/dist/*.js',
+      './node_modules/@g123jp/g123-ui/dist/components/**/*.js',
+      './node_modules/@g123jp/g123-ui/dist/utils/**/*.js',
     ],
     // ... your other configs
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@g123jp/g123-ui",
-  "version": "2.2.2-canary.18",
+  "version": "2.3.0",
   "description": "Reuseable UI based on G123 Design System",
   "author": "hydRAnger <armyiljfe@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@g123jp/g123-ui",
-  "version": "2.2.1",
+  "version": "2.2.2-canary.18",
   "description": "Reuseable UI based on G123 Design System",
   "author": "hydRAnger <armyiljfe@gmail.com>",
   "license": "MIT",
@@ -10,13 +10,16 @@
   },
   "keywords": [],
   "homepage": "",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "sideEffects": false,
+  "exports": "./dist/index.js",
   "types": "dist/types",
   "scripts": {
     "generate-icons": "node src/components/Atoms/Icon/generateIcons.mjs",
     "build": "yarn generate-icons && rollup -c rollup.config.prod.ts",
-    "dev-build": "rollup -c rollup.config.dev.ts",
+    "dev-build": "yarn generate-icons && rollup -c rollup.config.dev.ts",
     "lint": "tsc --noEmit && eslint \"./**/*.ts\" \"./**/*.tsx\"",
     "fix": "eslint --fix \"./**/*.ts\" \"./**/*.tsx\"",
     "storybook": "storybook dev -p 6006",
@@ -109,7 +112,6 @@
     }
   },
   "dependencies": {
-    "classnames": "^2.3.2",
     "react-hot-toast": "^2.4.1",
     "tailwind-merge": "^1.14.0"
   }

--- a/rollup.config.dev.ts
+++ b/rollup.config.dev.ts
@@ -10,16 +10,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
-      format: 'cjs',
-    },
-    {
-      file: pkg.module,
+      dir: 'dist',
       format: 'es',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
     },
   ],
   onwarn(warning, warn) {
-    // Akira: ignore warning caused by 'use client' in react-hot-toast@2.4.1
+    // Akira: ignore warning caused by 'use client'
     // ref: https://github.com/TanStack/query/issues/5175#issuecomment-1482196558
     if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
       return;

--- a/rollup.config.prod.ts
+++ b/rollup.config.prod.ts
@@ -11,16 +11,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
-      format: 'cjs',
-    },
-    {
-      file: pkg.module,
+      dir: 'dist',
       format: 'es',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
     },
   ],
   onwarn(warning, warn) {
-    // Akira: ignore warning caused by 'use client' in react-hot-toast@2.4.1
+    // Akira: ignore warning caused by 'use client'
     // ref: https://github.com/TanStack/query/issues/5175#issuecomment-1482196558
     if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
       return;

--- a/src/components/Atoms/Badge.tsx
+++ b/src/components/Atoms/Badge.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import classnames from '@/utils/classnames';
 import React, { ReactNode } from 'react';
 
 type Props = {

--- a/src/components/Atoms/Button.stories.tsx
+++ b/src/components/Atoms/Button.stories.tsx
@@ -1,11 +1,12 @@
 import { StoryFn, Meta } from '@storybook/react';
 import React from 'react';
-import toast, { Toaster } from 'react-hot-toast';
+
+import toast, { Toaster } from '../Molecules/Toast';
 
 import Button from './Button';
 import { ChatOutlined } from './Icon';
 
-import { ButtonSize, ButtonType } from '.';
+import { ButtonSize, ButtonType } from './index';
 
 export default {
   title: 'Atoms/Button',

--- a/src/components/Atoms/Button.tsx
+++ b/src/components/Atoms/Button.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/button-has-type */
-import classnames from 'classnames';
+import classnames from '@/utils/classnames';
 import React, { ReactNode, useCallback, useMemo } from 'react';
 import { twMerge } from 'tailwind-merge';
 

--- a/src/components/Atoms/Icon/Icons.stories.tsx
+++ b/src/components/Atoms/Icon/Icons.stories.tsx
@@ -54,7 +54,7 @@ import {
   PlayFilled,
   PlayOutlined,
   PlayTwoTone,
-} from '.';
+} from './index';
 
 export default {
   title: 'Atoms/Icons',

--- a/src/components/Atoms/Switch.tsx
+++ b/src/components/Atoms/Switch.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import classnames from '@/utils/classnames';
 import React, { useCallback } from 'react';
 
 type Props = {

--- a/src/components/Molecules/Breadcrumb.stories.tsx
+++ b/src/components/Molecules/Breadcrumb.stories.tsx
@@ -1,10 +1,10 @@
 import { StoryFn, Meta } from '@storybook/react';
 import React from 'react';
-import toast, { Toaster } from 'react-hot-toast';
 
 import { Button, ButtonType } from '../Atoms';
 
 import Breadcrumb from './Breadcrumb';
+import toast, { Toaster } from './Toast';
 
 export default {
   title: 'Molecules/Breadcrumb',

--- a/src/components/Molecules/Breadcrumb.tsx
+++ b/src/components/Molecules/Breadcrumb.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import classnames from '@/utils/classnames';
 import React, { ReactElement, cloneElement, isValidElement } from 'react';
 import { twMerge } from 'tailwind-merge';
 

--- a/src/components/Molecules/Toast.stories.tsx
+++ b/src/components/Molecules/Toast.stories.tsx
@@ -1,5 +1,5 @@
+import classnames from '@/utils/classnames';
 import { StoryFn, Meta } from '@storybook/react';
-import classnames from 'classnames';
 import React from 'react';
 
 import { Button, ButtonSize, ButtonType } from '../Atoms';

--- a/src/components/Molecules/Toast.tsx
+++ b/src/components/Molecules/Toast.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonType, Icon } from '@/components/Atoms';
-import classnames from 'classnames';
+import classnames from '@/utils/classnames';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import toast, {
   Renderable,

--- a/src/components/Molecules/VipBadge.tsx
+++ b/src/components/Molecules/VipBadge.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import classnames from '@/utils/classnames';
 import React from 'react';
 
 type Props = {

--- a/src/components/Organisms/Dialog/Dialog.stories.tsx
+++ b/src/components/Organisms/Dialog/Dialog.stories.tsx
@@ -1,9 +1,10 @@
 import { Button, ButtonType } from '@/components/Atoms';
 import { StoryFn, Meta } from '@storybook/react';
 import React from 'react';
-import toast, { Toaster } from 'react-hot-toast';
 
-import Dialog, { dialog, DialogContainer } from '.';
+import toast, { Toaster } from '../../Molecules/Toast';
+
+import Dialog, { dialog, DialogContainer } from './index';
 
 export default {
   title: 'Organisms/Dialog',

--- a/src/components/Organisms/Dialog/Dialog.tsx
+++ b/src/components/Organisms/Dialog/Dialog.tsx
@@ -1,7 +1,7 @@
 // FIXME: Akira: Legacy of Edward
 import { Logo, Button, ButtonType } from '@/components/Atoms';
 import { CloseOutlined } from '@/components/Atoms/Icon';
-import classnames from 'classnames';
+import classnames from '@/utils/classnames';
 import React, { ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
 

--- a/src/components/Organisms/Drawer/Drawer.stories.tsx
+++ b/src/components/Organisms/Drawer/Drawer.stories.tsx
@@ -1,9 +1,9 @@
+import classnames from '@/utils/classnames';
 import { useArgs } from '@storybook/client-api';
 import { StoryFn, Meta } from '@storybook/react';
-import classnames from 'classnames';
 import React from 'react';
 
-import Drawer from '.';
+import Drawer from './index';
 
 export default {
   title: 'Organisms/Drawer',

--- a/src/components/Organisms/Drawer/index.tsx
+++ b/src/components/Organisms/Drawer/index.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonType } from '@/components/Atoms';
 import { ChevronLeftOutlined, CloseOutlined } from '@/components/Atoms/Icon';
-import classnames from 'classnames';
+import classnames from '@/utils/classnames';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 

--- a/src/components/Organisms/Modal/Modal.stories.tsx
+++ b/src/components/Organisms/Modal/Modal.stories.tsx
@@ -2,7 +2,7 @@ import { Logo, Avatar } from '@/components/Atoms';
 import { StoryFn, Meta } from '@storybook/react';
 import React from 'react';
 
-import Modal from '.';
+import Modal from './index';
 
 export default {
   title: 'Organisms/Modal',

--- a/src/utils/classnames.ts
+++ b/src/utils/classnames.ts
@@ -1,0 +1,36 @@
+const hasOwn = {}.hasOwnProperty;
+
+function classnames(...args: any[]): string {
+  const classes: string[] = [];
+
+  args.forEach((arg) => {
+    if (!arg) return;
+
+    const argType = typeof arg;
+
+    if (argType === 'string' || argType === 'number') {
+      classes.push(arg.toString());
+    } else if (Array.isArray(arg)) {
+      const innerClassnames = classnames(...arg);
+      innerClassnames && classes.push(innerClassnames);
+    } else if (argType === 'object') {
+      if (
+        arg.toString !== Object.prototype.toString &&
+        !arg.toString.toString().includes('[native code]')
+      ) {
+        classes.push(arg.toString());
+        return;
+      }
+
+      Object.keys(arg).forEach((key) => {
+        if (hasOwn.call(arg, key) && arg[key]) {
+          classes.push(key);
+        }
+      });
+    }
+  });
+
+  return Array.from(new Set(classes)).join(' ');
+}
+
+export default classnames;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
+export { default as classnames } from './classnames';
 export * from './color_helper';
 export * from './size_helper';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,11 +3820,6 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
 
-classnames@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
-
 clean-css@^5.2.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.2.tgz#70ecc7d4d4114921f5d298349ff86a31a9975224"


### PR DESCRIPTION
ticket: https://app.clickup.com/t/860t3ey8a

- [x] 默认按esm输出
- [x] [disable sideEffects](https://webpack.js.org/guides/tree-shaking/)
- [x] rollup启用[preserveModules](https://stackoverflow.com/questions/55339256/tree-shaking-with-rollup/72365809)
- [x] 使用自己手作的classnames，替换掉[JedWatson/classnames](https://github.com/JedWatson/classnames), 并作为utils导出
- [x] 文档调整 